### PR TITLE
github-hosted-runner-fallback

### DIFF
--- a/.github/workflows/build-from-dotfiles.yml
+++ b/.github/workflows/build-from-dotfiles.yml
@@ -1,8 +1,13 @@
 name: Build Desktop Environment From Dotfiles
 on: [workflow_dispatch]
 jobs:
+  select-runner:
+    uses: ./.github/workflows/select-runner.yml
+    secrets: inherit
+
   build:
-    runs-on: ubuntu-latest
+    needs: select-runner
+    runs-on: ${{ needs.select-runner.outputs.runner }}
     permissions:
       actions: read
       packages: write
@@ -15,6 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
+        if: needs.select-runner.outputs.runner != 'self-hosted'
         uses: docker/setup-buildx-action@v3
 
       - name: Sanitise repository owner
@@ -41,9 +47,7 @@ jobs:
         run: |
           ./docker/scripts/build.sh \
             --build-arg CACHEBUST_DOTFILES=${{ github.sha }} \
-            --cache-from type=gha \
-            --cache-to type=gha,mode=max \
-            --load \
+            ${{ needs.select-runner.outputs.runner == 'self-hosted' && format('--cache-from type=registry,ref=ghcr.io/{0}/desktop-environment:latest', env.REPOSITORY_OWNER) || '--cache-from type=gha --cache-to type=gha,mode=max --load' }} \
             --progress=plain 2>&1 | tee /tmp/build.log
 
       - name: Record build end

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,13 @@
 name: Build Desktop Environment
 on: [push, workflow_call]
 jobs:
+  select-runner:
+    uses: ./.github/workflows/select-runner.yml
+    secrets: inherit
+
   build:
-    runs-on: self-hosted
+    needs: select-runner
+    runs-on: ${{ needs.select-runner.outputs.runner }}
     permissions:
       actions: read
       packages: write
@@ -16,6 +21,10 @@ jobs:
 
       - name: Check out repository
         uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        if: needs.select-runner.outputs.runner != 'self-hosted'
+        uses: docker/setup-buildx-action@v3
 
       - name: Sanitise repository owner
         run: echo REPOSITORY_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
@@ -40,7 +49,7 @@ jobs:
           DESKTOP_ENVIRONMENT_USER: ${{ env.REPOSITORY_OWNER }}
         run: |
           ./docker/scripts/build.sh \
-            --cache-from type=registry,ref=ghcr.io/${{ env.REPOSITORY_OWNER }}/desktop-environment:latest \
+            ${{ needs.select-runner.outputs.runner == 'self-hosted' && format('--cache-from type=registry,ref=ghcr.io/{0}/desktop-environment:latest', env.REPOSITORY_OWNER) || '--cache-from type=gha --cache-to type=gha,mode=max --load' }} \
             --progress=plain 2>&1 | tee /tmp/build.log
 
       - name: Record build end

--- a/.github/workflows/select-runner.yml
+++ b/.github/workflows/select-runner.yml
@@ -1,0 +1,24 @@
+name: Select Runner
+on:
+  workflow_call:
+    outputs:
+      runner:
+        value: ${{ jobs.select-runner.outputs.runner }}
+jobs:
+  select-runner:
+    runs-on: ubuntu-latest
+    outputs:
+      runner: ${{ steps.select.outputs.runner }}
+    steps:
+      - name: Check for online self-hosted runners
+        id: select
+        env:
+          GH_TOKEN: ${{ secrets.ACTIONS_RUNNER_CHECK_TOKEN || github.token }}
+        run: |
+          if ONLINE=$(gh api repos/${{ github.repository }}/actions/runners --jq '[.runners[] | select(.status == "online")] | length') && [ $ONLINE -gt 0 ]; then
+            echo "Found $ONLINE online self-hosted runner(s)"
+            echo "runner=self-hosted" >> $GITHUB_OUTPUT
+          else
+            echo "No self-hosted runners available, using ubuntu-latest"
+            echo "runner=ubuntu-latest" >> $GITHUB_OUTPUT
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,14 @@ A read from the live system is current by definition; a cached file is not. Stal
 
 ---
 
+# GitHub Actions workflow conventions
+
+- In GitHub Actions expressions, `||` already handles falsy/empty values. Do not use redundant `!= ''` checks — write `${{ secrets.MY_SECRET || github.token }}`, not `${{ secrets.MY_SECRET != '' && secrets.MY_SECRET || github.token }}`.
+- Prefer ternary expressions (`${{ condition && 'a' || 'b' }}`) over duplicate conditional steps when only a parameter value differs between runner types.
+- Keep reusable logic (e.g. runner selection) in standalone `workflow_call` workflows under `.github/workflows/` so it can be shared across all workflow files.
+
+---
+
 # Testing changes before finishing
 
 Before telling the user a task is complete, always verify the change is correct by testing it. For Dockerfile changes:


### PR DESCRIPTION
## Summary
- Adds a `select-runner` job that checks if any self-hosted runners are online via the GitHub API
- Falls back to `ubuntu-latest` when no self-hosted runners are available (or if the API call fails)
- Adjusts Docker Buildx driver and cache strategy based on the selected runner type:
  - **Self-hosted**: `driver: docker` with registry cache
  - **GitHub-hosted**: default driver with GHA cache, `load: true`

## Test plan
- [ ] Verify workflow runs successfully on GitHub-hosted runner when self-hosted is offline
- [ ] Verify workflow selects self-hosted runner when one is online
- [ ] Verify Docker build and push steps complete on GitHub-hosted runner

https://claude.ai/code/session_014dKaZy9q2PsPAaStVeNe33