### PR TITLE
uv-unmanaged-install

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -276,7 +276,7 @@ RUN nala update && \
   ln -s $HOME/.cargo/bin/rustup /usr/local/bin
 
 # Install uv
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+RUN curl -fsSL https://astral.sh/uv/install.sh | UV_UNMANAGED_INSTALL=/usr/local/bin sh
 
 # Install alacritty
 RUN nala install libfreetype6-dev libfontconfig1-dev libxcb-xfixes0-dev libxkbcommon-dev python3 && \


### PR DESCRIPTION
## Summary
- Install uv directly to `/usr/local/bin` using `UV_UNMANAGED_INSTALL` instead of the default `$HOME/.local/bin`
- Fixes uv not being on PATH in subsequent Docker RUN steps (masked by cached layers on self-hosted runner)

https://claude.ai/code/session_014dKaZy9q2PsPAaStVeNe33